### PR TITLE
Updating docker-compose to be usable for GCP ingestion

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,12 +70,16 @@ x-airflow-common:
     AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
-    _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
+    _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:- apache-airflow-providers-google}
+    # Piggyback local GCP credentials
+    GOOGLE_APPLICATION_CREDENTIALS: /gcp/config/application_default_credentials.json
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
+    - ${AIRFLOW_PROJ_DIR:-.}/data:/opt/airflow/data
+    - ~/.config/gcloud/application_default_credentials.json:/gcp/config/application_default_credentials.json
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on
@@ -232,7 +236,7 @@ services:
           echo
         fi
         mkdir -p /sources/logs /sources/dags /sources/plugins
-        chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
+        chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,data,plugins}
         exec /entrypoint airflow version
     # yamllint enable rule:line-length
     environment:


### PR DESCRIPTION
The current implementation does not include any providers or a `data` directory. This PR adds these, the provider package is from Google and the users local credentials are mounted to the instance.